### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,6 +16,6 @@ jobs:
     - name: make compile
       run: make compile
     - name: Github Release
-      uses: elgohr/Github-Release-Action@v3.1
+      uses: elgohr/Github-Release-Action@v4
       with:
         run: hub release create -a triplex -F triplex


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore